### PR TITLE
Add CutPlugin class for cuts in straxen

### DIFF
--- a/strax/plugin.py
+++ b/strax/plugin.py
@@ -847,3 +847,50 @@ class ParallelSourcePlugin(Plugin):
             for s in savers:
                 s.close(wait_for=wait_for)
         super().cleanup(iters, wait_for)
+
+
+@export
+class CutPlugin(Plugin):
+    """Generate a plugin that provides a boolean for a given cut specified by 'cut_by'"""
+    save_when = SaveWhen.NEVER
+
+    def __init__(self):
+        super().__init__()
+
+        _name = strax.camel_to_snake(self.__class__.__name__)
+        if not hasattr(self, 'provides'):
+            self.provides = _name
+        if not hasattr(self, 'cut_name'):
+            self.cut_name = _name
+        if not hasattr(self, 'cut_description'):
+            _description = _name
+            if 'cut_' not in _description:
+                _description = 'Cut by ' + _description
+            else:
+                _description = " ".join(_description.split("_"))
+            self.cut_description = _description
+
+    def infer_dtype(self):
+        dtype = [(self.cut_name, np.bool, self.cut_description)]
+        dtype = dtype + strax.time_fields
+        return dtype
+
+    def compute(self, **kwargs):
+        if hasattr(self, 'cut_by'):
+            cut_by = self.cut_by
+        else:
+            raise NotImplementedError(f"{self.cut_name} does not have attribute 'cut_by'")
+
+        # Take shape of the first data_type like in strax.plugin
+        buff = list(kwargs.values())[0]
+
+        # Generate result buffer
+        r = np.zeros(len(buff), self.dtype)
+        r['time'] = buff['time']
+        r['endtime'] = buff['endtime']
+        r[self.cut_name] = cut_by(**kwargs)
+        return r
+
+    def cut_by(self, **kwargs):
+        # This should be provided by the user making a CutPlugin
+        raise NotImplementedError()


### PR DESCRIPTION
The cuts currently in straxen (https://github.com/XENONnT/straxen/blob/master/straxen/plugins/x1t_cuts.py ) have a quite lot of overlap with one another. Most of the time a simple Boolean array is all that is returned. However, we each time have to add the time fields et cetera which may somewhat obscure the functionality.
To simplify the cuts somewhat I've written a simple Plugin Class. In straxen it could be used as for example:
```
class CutS1s(CutPlugin):
    depends_on = ('events', 'corrected_areas')
    provides = 'cs1_cut'
    cut_description = "Remove cS1 above 100 PE"
    cut_name ='cut_high_cs1'
    __version__ = '0.0.0'
    
    def cut_by(self, events):
        return events['cs1'] > 100
```
```
class CutS2s(CutPlugin):
    depends_on = ('events', 'corrected_areas')
    cut_description = "Remove cS2s below 100 PE"
    
    def cut_by(self, events):
        return events['cs2'] < 100
```
